### PR TITLE
$regex op value handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function convertOp(path, op, value, parent, arrayPaths) {
       if (!parent['$options'] || !parent['$options'].includes('s')) {
         op2 += '(?p)'
       }
-      return util.pathToText(path, true) + ' ' + op + ' \'' + op2 + util.stringEscape(value) + '\''
+      return util.pathToText(path, true) + ' ' + op + ' \'' + op2 + util.stringEscape(value.source) + '\''
     case '$eq':
     case '$gt':
     case '$gte':


### PR DESCRIPTION
When using $regex op, the value type isn't a string.
It is a regex object, which means that we need to extract the source.


Signed-off-by: Evgeniy Belyi <jeniawhite92@gmail.com>