### PR TITLE
Addition of test cases for $regex and fix handling strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,10 +121,7 @@ function convertOp(path, op, value, parent, arrayPaths) {
         // partial newline-sensitive matching
         op2 += '(?p)'
       }
-      if (value instanceof RegExp) {
-        value = value.source
-      }
-      return util.pathToText(path, true) + ' ' + op + ' \'' + op2 + util.stringEscape(value) + '\''
+      return util.pathToText(path, true) + ' ' + op + ' \'' + op2 + util.stringEscape(typeof value === 'string' ? value : value.source) + '\''
     case '$eq':
     case '$gt':
     case '$gte':

--- a/test/filter.js
+++ b/test/filter.js
@@ -133,6 +133,9 @@ describe('regular expressions', function() {
   it('js RegExp using regex', function () {
     assert.equal('data->>\'type\' ~ \'(?p)food\'', convert('data', { type: { $regex: /food/ }}))
   })
+  it('js RegExp using regex with options case insensitive', function () {
+    assert.equal('data->>\'type\' ~* \'(?p)food\'', convert('data', { type: { $regex : /food/, $options: 'i' } }))
+  })
   it('make dot match multiline', function () {
     assert.equal('data->>\'type\' ~* \'food\'', convert('data', { type: { $regex : 'food', $options: 'si' } }))
   })


### PR DESCRIPTION
Added two cases for MongoDB $regex usage:
1) Case of $regex without options.
2) Case of $regex with options.
Fixed handling of strings in $regex field (missed that part on MongoDB documentation).

Signed-off-by: Evgeniy Belyi <jeniawhite92@gmail.com>