### PR TITLE
Patching numeric operators in edge cases

### DIFF
--- a/test/update.js
+++ b/test/update.js
@@ -38,18 +38,18 @@ describe('update: ', function() {
     })
 
     it('$inc', function() {
-      assert.equal(convertUpdate('data', { $inc: { count: 2 } }), 'jsonb_set(data,\'{count}\',to_jsonb(Cast(data->>\'count\' as numeric)+2))')
+      assert.equal(convertUpdate('data', { $inc: { count: 2 } }), 'jsonb_set(data,\'{count}\',to_jsonb(COALESCE(Cast(data->>\'count\' as numeric),0)+2))')
     })
     it('$mul', function() {
-      assert.equal(convertUpdate('data', { $mul: { count: 2 } }), 'jsonb_set(data,\'{count}\',to_jsonb(Cast(data->>\'count\' as numeric)*2))')
+      assert.equal(convertUpdate('data', { $mul: { count: 2 } }), 'jsonb_set(data,\'{count}\',to_jsonb(COALESCE(Cast(data->>\'count\' as numeric),0)*2),TRUE)')
     })
 
 
     it('$min', function() {
-      assert.equal(convertUpdate('data', { $min: { count: 5 } }), 'jsonb_set(data,\'{count}\',to_jsonb(LEAST(Cast(data->>\'count\' as numeric),5)))')
+      assert.equal(convertUpdate('data', { $min: { count: 5 } }), 'jsonb_set(data,\'{count}\',to_jsonb(LEAST(COALESCE(Cast(data->>\'count\' as numeric),0),5)))')
     })
     it('$max', function() {
-      assert.equal(convertUpdate('data', { $max: { count: 5 } }), 'jsonb_set(data,\'{count}\',to_jsonb(GREATEST(Cast(data->>\'count\' as numeric),5)))')
+      assert.equal(convertUpdate('data', { $max: { count: 5 } }), 'jsonb_set(data,\'{count}\',to_jsonb(GREATEST(COALESCE(Cast(data->>\'count\' as numeric),0),5)))')
     })
 
     it('$rename', function() {
@@ -67,6 +67,11 @@ describe('update: ', function() {
   })
 
   describe('combined operators', function() {
-    assert.equal(convertUpdate('data', { $set: { active: true }, $inc: { purchases: 2 } }), 'jsonb_set(jsonb_set(data,\'{active}\',\'true\'::jsonb),\'{purchases}\',to_jsonb(Cast(data->>\'purchases\' as numeric)+2))')
+    it('$set,$inc', function() {
+      assert.equal(convertUpdate('data', { $set: { active: true }, $inc: { purchases: 2 } }), 'jsonb_set(jsonb_set(data,\'{active}\',\'true\'::jsonb),\'{purchases}\',to_jsonb(COALESCE(Cast(data->>\'purchases\' as numeric),0)+2))')
+    })
+    it('$set,$unset,$inc', function() {
+      assert.equal(convertUpdate('data', { $set: { active: true }, $unset: { field: 'value' }, $inc: { purchases: 2 } }), 'jsonb_set(jsonb_set(data,\'{active}\',\'true\'::jsonb) #- \'{field}\',\'{purchases}\',to_jsonb(COALESCE(Cast(data->>\'purchases\' as numeric),0)+2))')
+    })
   })
 })

--- a/update.js
+++ b/update.js
@@ -32,12 +32,16 @@ function convertOp(input, op, data, fieldName, upsert) {
     case '$unset':
       return input + ' #- ' + pgPath
     case '$inc':
+      // TODO: Handle null value keys (MongoDB drops the operation with "Cannot apply $inc to a value of non-numeric type null")
       return 'jsonb_set(' + input + ',' + pgPath + ',to_jsonb(' + prevNumericVal + '+' + value + '))'
     case '$mul':
-      return 'jsonb_set(' + input + ',' + pgPath + ',to_jsonb(' + prevNumericVal + '*' + value + '))'
+      // TODO: Handle null value keys (MongoDB drops the operation with "Cannot apply $mul to a value of non-numeric type null")
+      return 'jsonb_set(' + input + ',' + pgPath + ',to_jsonb(' + prevNumericVal + '*' + value + '),TRUE)'
     case '$min':
+      // TODO: $min between existing key with value null with anything will output null
       return 'jsonb_set(' + input + ',' + pgPath + ',to_jsonb(LEAST(' + prevNumericVal + ',' + value + ')))'
     case '$max':
+      // TODO: $max between existing key with value null with anything will output value
       return 'jsonb_set(' + input + ',' + pgPath + ',to_jsonb(GREATEST(' + prevNumericVal + ',' + value + ')))'
     case '$rename':
       const pgNewPath = util.toPostgresPath(value.split('.'))

--- a/util.js
+++ b/util.js
@@ -46,7 +46,7 @@ exports.toPostgresPath = function(path) {
 }
 
 exports.toNumeric = function(path) {
-  return 'Cast(' + path + ' as numeric)'
+  return 'COALESCE(Cast(' + path + ' as numeric),0)'
 }
 
 const typeMapping = {


### PR DESCRIPTION
The list of available operators upon update:
https://docs.mongodb.com/manual/reference/operator/update/#id1
This PR handles numerical operators: $min, $max, $inc, $mul.
Currently, in case of non-existing values / null values, the `data` would be overridden with null and lost (corruption).
Example:
```
CREATE TABLE test 
(   id int,
    data  jsonb
);

INSERT INTO test(id,data) VALUES
    (1,'{"_id":"1", "count":2}'),
    (2,'{"_id":"2", "count":0}'),
    (3,'{"_id":"3", "count":null}'),
    (4,'{"_id":"4"}')
   ;
```
Run the query that is generated by the library:
```
convertUpdate('data', { $mul: { count: 2 } })
jsonb_set(data,'{count}',to_jsonb(Cast(data->>'count' as numeric)*2))
UPDATE test SET data = jsonb_set(data,'{count}',to_jsonb(Cast(data->>'count' as numeric)*2))
```
Which will cause row 3 and 4 to be null (thus corrupting the data).
There are some gaps with the fix that I've provided.
1) Running these operators on non-numeric types should be thrown
2) $min and $max handling of null values