### PR TITLE
Add Support for deeper update using $set

### DIFF
--- a/test/update.js
+++ b/test/update.js
@@ -23,6 +23,9 @@ describe('update: ', function() {
     it('$set deep', function() {
       assert.equal(convertUpdate('data', { $set: { 'a.b': 2 } }), 'jsonb_set(jsonb_set(data,\'{a}\',COALESCE(data->\'a\', \'{}\'::jsonb)),\'{a,b}\',\'2\'::jsonb)')
     })
+    it('$set deep 2', function() {
+      assert.equal(convertUpdate('data', { $set: { 'a.b.c': 2 } }), 'jsonb_set(jsonb_set(jsonb_set(data,\'{a}\',COALESCE(data->\'a\', \'{}\'::jsonb)),\'{a,b}\',COALESCE(data->\'a\'->\'b\', \'{}\'::jsonb)),\'{a,b,c}\',\'2\'::jsonb)')
+    })
     it('$set fails for _id', function() {
       assert.throws(() => convertUpdate('data', { $set: { _id: 'b' } }), 'Mod on _id not allowed')
     })

--- a/update.js
+++ b/update.js
@@ -18,9 +18,10 @@ function convertOp(input, op, data, fieldName, upsert) {
       // Create the necessary top level keys since jsonb_set will not create them automatically.
       if (path.length > 1) {
         for (let i = 0; i < path.length - 1; i++) {
-          const parentPath = util.toPostgresPath([path[i]])
+          const slice = path.slice(0, i + 1)
+          const parentPath = util.toPostgresPath(slice)
           if (!input.includes(parentPath)) {
-            const parentValue = upsert ? '\'{}\'::jsonb' : `COALESCE(${util.pathToText([fieldName].concat(path.slice(0, i + 1)))}, '{}'::jsonb)`
+            const parentValue = upsert ? '\'{}\'::jsonb' : `COALESCE(${util.pathToText([fieldName].concat(slice))}, '{}'::jsonb)`
             input = 'jsonb_set(' + input + ',' + parentPath + ',' + parentValue + ')'
           }
         }


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

This PR handles an issue I observed when executing updates using $set op with more than 1 '.' .

### **For example:** 

**When calling:** 
convertUpdate('data', { $set: { 'a.b.c': 2 } }

**Actual Postgres query:** 
```jsonb_set(jsonb_set(jsonb_set(data,'{a}',COALESCE(data->'a', '{}'::jsonb)),'{b}',COALESCE(data->'a'->'b', '{}'::jsonb)),'{a,b,c}','2'::jsonb)```

This query indeed updates a.b.c as wanted but it also "hangs" the old value of a.b on a.
 
**Expected Postgres query:** 
```jsonb_set(jsonb_set(jsonb_set(data,'{a}',COALESCE(data->'a', '{}'::jsonb)),'{a,b}',COALESCE(data->'a'->'b', '{}'::jsonb)),'{a,b,c}','2'::jsonb)```

Please review,
Thank you.