### PR TITLE
provide a way to avoid using containment operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,14 +34,14 @@ function getMatchingArrayPath(op, arrayPaths) {
  * @param arrayPathStr
  * @returns {string|string|*}
  */
-function createElementOrArrayQuery(path, op, value, parent, arrayPathStr) {
+function createElementOrArrayQuery(path, op, value, parent, arrayPathStr, options) {
   const arrayPath = arrayPathStr.split('.')
   const deeperPath = op.split('.').slice(arrayPath.length)
   const innerPath = ['value', ...deeperPath]
   const pathToMaybeArray = path.concat(arrayPath)
 
   // TODO: nested array paths are not yet supported.
-  const singleElementQuery = convertOp(path, op, value, parent, [])
+  const singleElementQuery = convertOp(path, op, value, parent, [], options)
 
   const text = util.pathToText(pathToMaybeArray, false)
   const safeArray = `jsonb_typeof(${text})='array' AND`
@@ -52,30 +52,30 @@ function createElementOrArrayQuery(path, op, value, parent, arrayPathStr) {
     if (typeof value['$size'] !== 'undefined') {
       // size does not support array element based matching
     } else if (value['$elemMatch']) {
-      const sub = convert(innerPath, value['$elemMatch'], [], false)
+      const sub = convert(innerPath, value['$elemMatch'], [], false, options)
       arrayQuery = `EXISTS (SELECT * FROM jsonb_array_elements(${text}) WHERE ${safeArray} ${sub})`
       return arrayQuery
     } else if (value['$in']) {
-      const sub = convert(innerPath, value, [], true)
+      const sub = convert(innerPath, value, [], true, options)
       arrayQuery = `EXISTS (SELECT * FROM jsonb_array_elements(${text}) WHERE ${safeArray} ${sub})`
     } else if (value['$all']) {
       const cleanedValue = value['$all'].filter((v) => (v !== null && typeof v !== 'undefined'))
       arrayQuery = '(' + cleanedValue.map(function (subquery) {
-        const sub = convert(innerPath, subquery, [], false)
+        const sub = convert(innerPath, subquery, [], false, options)
         return `EXISTS (SELECT * FROM jsonb_array_elements(${text}) WHERE ${safeArray} ${sub})`
       }).join(' AND ') + ')'
     } else if (specialKeys.length === 0) {
-      const sub = convert(innerPath, value, [], true)
+      const sub = convert(innerPath, value, [], true, options)
       arrayQuery = `EXISTS (SELECT * FROM jsonb_array_elements(${text}) WHERE ${safeArray} ${sub})`
     } else {
       const params = value
       arrayQuery = '(' + Object.keys(params).map(function (subKey) {
-        const sub = convert(innerPath, { [subKey]: params[subKey] }, [], true)
+        const sub = convert(innerPath, { [subKey]: params[subKey] }, [], true, options)
         return `EXISTS (SELECT * FROM jsonb_array_elements(${text}) WHERE ${safeArray} ${sub})`
       }).join(' AND ') + ')'
     }
   } else {
-    const sub = convert(innerPath, value, [], true)
+    const sub = convert(innerPath, value, [], true, options)
     arrayQuery = `EXISTS (SELECT * FROM jsonb_array_elements(${text}) WHERE ${safeArray} ${sub})`
   }
   if (!arrayQuery || arrayQuery === '()') {
@@ -91,17 +91,17 @@ function createElementOrArrayQuery(path, op, value, parent, arrayPathStr) {
  * @param parent {mixed} parent[path] = value
  * @param arrayPaths {Array} List of dotted paths that possibly need to be handled as arrays.
  */
-function convertOp(path, op, value, parent, arrayPaths) {
+function convertOp(path, op, value, parent, arrayPaths, options) {
   const arrayPath = getMatchingArrayPath(op, arrayPaths)
   // It seems like direct matches shouldn't be array fields, but 2D arrays are possible in MongoDB
   // I will need to do more testing to see if we should handle this case differently.
   // const arrayDirectMatch = !isSpecialOp(op) && Array.isArray(value)
   if (arrayPath) {
-    return createElementOrArrayQuery(path, op, value, parent, arrayPath)
+    return createElementOrArrayQuery(path, op, value, parent, arrayPath, options)
   }
   switch(op) {
     case '$not':
-      return '(NOT ' + convert(path, value) + ')'
+      return '(NOT ' + convert(path, value, undefined, false, options) + ')'
     case '$nor': {
       for (const v of value) {
         if (typeof v !== 'object') {
@@ -109,7 +109,7 @@ function convertOp(path, op, value, parent, arrayPaths) {
         }
       }
       const notted = value.map((e) => ({ $not: e }))
-      return convertOp(path, '$and', notted, value, arrayPaths)
+      return convertOp(path, '$and', notted, value, arrayPaths, options)
     }
     case '$or':
     case '$and':
@@ -124,11 +124,11 @@ function convertOp(path, op, value, parent, arrayPaths) {
             throw new Error('$or/$and/$nor entries need to be full objects')
           }
         }
-        return '(' + value.map((subquery) => convert(path, subquery, arrayPaths)).join(op === '$or' ? ' OR ' : ' AND ') + ')'
+        return '(' + value.map((subquery) => convert(path, subquery, arrayPaths, false, options)).join(op === '$or' ? ' OR ' : ' AND ') + ')'
       }
     // TODO (make sure this handles multiple elements correctly)
     case '$elemMatch':
-      return convert(path, value, arrayPaths)
+      return convert(path, value, arrayPaths, false, options)
       //return util.pathToText(path, false) + ' @> \'' + util.stringEscape(JSON.stringify(value)) + '\'::jsonb'
     case '$in':
     case '$nin': {
@@ -136,7 +136,7 @@ function convertOp(path, op, value, parent, arrayPaths) {
         return 'FALSE'
       }
       if (value.length === 1) {
-        return convert(path, value[0], arrayPaths)
+        return convert(path, value[0], arrayPaths, false, options)
       }
       const cleanedValue = value.filter((v) => (v !== null && typeof v !== 'undefined'))
       let partial = util.pathToText(path, typeof value[0] == 'string') + (op == '$nin' ? ' NOT' : '') + ' IN (' + cleanedValue.map(util.quote).join(', ') + ')'
@@ -172,7 +172,7 @@ function convertOp(path, op, value, parent, arrayPaths) {
     case '$eq':  {
       const isSimpleComparision = (op === '$eq' || op === '$ne')
       const pathContainsArrayAccess = path.some((key) => /^\d+$/.test(key))
-      if (isSimpleComparision && !pathContainsArrayAccess) {
+      if (isSimpleComparision && !pathContainsArrayAccess && !options.disableContainmentQuery) {
         // create containment query since these can use GIN indexes
         // See docs here, https://www.postgresql.org/docs/9.4/datatype-json.html#JSON-INDEXING
         const [head, ...tail] = path
@@ -213,7 +213,7 @@ function convertOp(path, op, value, parent, arrayPaths) {
     }
     default:
       // this is likely a top level field, recurse
-      return convert(path.concat(op.split('.')), value)
+      return convert(path.concat(op.split('.')), value, undefined, false, options)
   }
 }
 
@@ -236,9 +236,9 @@ function getSpecialKeys(path, query, forceExact) {
  * @param forceExact {Boolean} When true, an exact match will be required.
  * @returns The corresponding PSQL expression
  */
-var convert = function (path, query, arrayPaths, forceExact=false) {
+var convert = function (path, query, arrayPaths, forceExact, options) {
   if (typeof query === 'string' || typeof query === 'boolean' || typeof query == 'number' || Array.isArray(query)) {
-    return convertOp(path, '$eq', query, {}, arrayPaths)
+    return convertOp(path, '$eq', query, {}, arrayPaths, options)
   }
   if (query === null) {
     const text = util.pathToText(path, false)
@@ -261,18 +261,26 @@ var convert = function (path, query, arrayPaths, forceExact=false) {
       }
       case 1: {
         const key = specialKeys[0]
-        return convertOp(path, key, query[key], query, arrayPaths)
+        return convertOp(path, key, query[key], query, arrayPaths, options)
       }
       default:
         return '(' + specialKeys.map(function (key) {
-          return convertOp(path, key, query[key], query, arrayPaths)
+          return convertOp(path, key, query[key], query, arrayPaths, options)
         }).join(' and ') + ')'
     }
   }
 }
 
-module.exports = function (fieldName, query, arrays) {
-  return convert([fieldName], query, arrays || [])
+module.exports = function (fieldName, query, arraysOrOptions) {
+  let arrays
+  let options = {}
+  if (arraysOrOptions && Array.isArray(arraysOrOptions)) {
+    arrays = arraysOrOptions
+  } else if (typeof arraysOrOptions === 'object') {
+    arrays = arraysOrOptions.arrays || []
+    options = arraysOrOptions
+  }
+  return convert([fieldName], query, arrays || [], false, options)
 }
 module.exports.convertDotNotation = util.convertDotNotation
 module.exports.pathToText = util.pathToText

--- a/test/filter.js
+++ b/test/filter.js
@@ -238,3 +238,10 @@ describe('special cases', function () {
     assert.equal('TRUE', convert('data', {}))
   })
 })
+
+describe('options.disableContainmentQuery', function () {
+  it('should use ->> operator instead of containment when options.disableContainmentQuery is passed', function (){
+    assert.equal('(data->>\'a\'=\'1111\' and data->\'b\'=\'123\'::jsonb)', 
+      convert('data', { a: '1111', b: 123 }, {disableContainmentQuery: true}))
+  })
+})


### PR DESCRIPTION
when using a BTREE index, the use of containment operators prevents the query from hitting the index.
* Added `arraysOroptions` to the `convert` function
   * maintaining previous functionality - if an array is passed it is treated as before. if an object, it is treated as `options` and `arrays` can also be passed inside the options object
* If options.disableContainmentQuery is true then containment query is not used.
* Added a simple unit test to test convert with options

Signed-off-by: Danny Zaken <dannyzaken@gmail.com>